### PR TITLE
Proposal for a byte unit ontology

### DIFF
--- a/byte-units.ttl
+++ b/byte-units.ttl
@@ -25,90 +25,90 @@
     rdfs:label "Unit"@en .
 
 
-:Byte a :Unit
+:Byte a :Unit, rdfs:Datatype ;
     rdfs:comment "A byte datatype to set the multiple of bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "byte"@en .
 
-:Kilobyte a :Unit
+:Kilobyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A kilobyte (kB) datatype to set the multiple of 1000 * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "kB"@en .
 
-:Megabyte a :Unit
+:Megabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A megabyte (MB) datatype to set the multiple of 1000² * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "MB"@en .
 
-:Gigabyte a :Unit
+:Gigabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A gigabyte (GB) datatype to set the multiple of 1000³ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "GB"@en .
 
-:Terabyte a :Unit
+:Terabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A terabyte (TB) datatype to set the multiple of 1000⁴ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "TB"@en .
 
-:Petabyte a :Unit
+:Petabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A petabyte (PB) datatype to set the multiple of 1000⁵ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "PB"@en .
 
-:Exabyte a :Unit
+:Exabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A exabyte (EB) datatype to set the multiple of 1000⁶ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "EB"@en .
 
-:Zettabyte a :Unit
+:Zettabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A zettabyte (ZB) datatype to set the multiple of 1000⁷ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "ZB"@en .
 
-:Yottabyte a :Unit
+:Yottabyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A yottabyte (YB) datatype to set the multiple of 1000⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YB"@en .
 
 
 
-:Kibibyte a :Unit
+:Kibibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A kibibyte (kiB) datatype to set the multiple of 1024 * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "kiB"@en .
 
-:Mebibyte a :Unit
+:Mebibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A mebibyte (MiB) datatype to set the multiple of 1024² * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "MiB"@en .
 
 
-:Gibibyte a :Unit
+:Gibibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A gibibyte (GiB) datatype to set the multiple of 1024³ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "GiB"@en .
 
-:Tebibyte a :Unit
+:Tebibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A tebibyte (TiB) datatype to set the multiple of 1024⁴ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "TiB"@en .
 
-:Pebibyte a :Unit
+:Pebibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A pebibyte (PiB) datatype to set the multiple of 1024⁵ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "PiB"@en .
 
-:Exbibyte a :Unit
+:Exbibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A exbibyte (EiB) datatype to set the multiple of 1024⁶ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "EiB"@en .
 
-:Zebibyte a :Unit
+:Zebibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A zebibyte (ZiB) datatype to set the multiple of 1024⁷ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "ZiB"@en .
 
-:Yobibyte a :Unit
+:Yobibyte a :Unit, rdfs:Datatype ;
     rdfs:comment "A yobibyte (YiB) datatype to set the multiple of 1024⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YiB"@en .

--- a/byte-units.ttl
+++ b/byte-units.ttl
@@ -1,0 +1,134 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix cc: <https://creativecommons.org/ns#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+@prefix : <#> .
+
+<>
+    a owl:Ontology ;
+    cc:attributionURL <> ;
+    cc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    dcterms:issued "2018-10-25"^^xsd:date ;
+    dcterms:modified "2018-10-25"^^xsd:date ;
+    rdfs:label "Units of digital information as data types."@en ;
+    rdfs:comment "This ontology contains datatype properties that be used as units to measure the size of digital information, for example megabyte, tebibyte, etc. It is applied to a literal containing a non-negative integer which is the multiple of the unit."@en .
+
+
+
+:unit a owl:DatatypeProperty ;
+    rdfs:subPropertyOf xsd:nonNegativeInteger ;
+    rdfs:comment "A datatype unit to measure the size of digital information."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "unit"@en .
+
+
+:byte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A byte datatype to set the multiple of bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "byte"@en .
+
+:kilobyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A kilobyte (kB) datatype to set the multiple of 1000 * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "kB"@en .
+
+:megabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A megabyte (MB) datatype to set the multiple of 1000² * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "MB"@en .
+
+:gigabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A gigabyte (GB) datatype to set the multiple of 1000³ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "GB"@en .
+
+:terabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A terabyte (TB) datatype to set the multiple of 1000⁴ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "TB"@en .
+
+:petabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A petabyte (PB) datatype to set the multiple of 1000⁵ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "PB"@en .
+
+:exabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A exabyte (EB) datatype to set the multiple of 1000⁶ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "EB"@en .
+
+:zettabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A zettabyte (ZB) datatype to set the multiple of 1000⁷ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "ZB"@en .
+
+:yottabyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A yottabyte (YB) datatype to set the multiple of 1000² * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "YB"@en .
+
+
+
+:kibibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A kibibyte (kiB) datatype to set the multiple of 1024 * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "kiB"@en .
+
+:mebibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A mebibyte (MiB) datatype to set the multiple of 1024² * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "MiB"@en .
+
+
+:gibibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A gibibyte (GiB) datatype to set the multiple of 1024³ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "GiB"@en .
+
+:tebibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A tebibyte (TiB) datatype to set the multiple of 1024⁴ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "TiB"@en .
+
+:pebibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A pebibyte (PiB) datatype to set the multiple of 1024⁵ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "PiB"@en .
+
+:exbibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A exbibyte (EiB) datatype to set the multiple of 1024⁶ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "EiB"@en .
+
+:zebibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A zebibyte (ZiB) datatype to set the multiple of 1024⁷ * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "ZiB"@en .
+
+:yobibyte a owl:DatatypeProperty ;
+    rdfs:subPropertyOf :unit ;
+    rdfs:comment "A yobibyte (YiB) datatype to set the multiple of 1024² * bytes."@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:label "YiB"@en .
+
+
+	

--- a/byte-units.ttl
+++ b/byte-units.ttl
@@ -75,7 +75,7 @@
 
 :yottabyte a owl:DatatypeProperty ;
     rdfs:subPropertyOf :unit ;
-    rdfs:comment "A yottabyte (YB) datatype to set the multiple of 1000² * bytes."@en ;
+    rdfs:comment "A yottabyte (YB) datatype to set the multiple of 1000⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YB"@en .
 
@@ -126,7 +126,7 @@
 
 :yobibyte a owl:DatatypeProperty ;
     rdfs:subPropertyOf :unit ;
-    rdfs:comment "A yobibyte (YiB) datatype to set the multiple of 1024² * bytes."@en ;
+    rdfs:comment "A yobibyte (YiB) datatype to set the multiple of 1024⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YiB"@en .
 

--- a/byte-units.ttl
+++ b/byte-units.ttl
@@ -18,114 +18,97 @@
 
 
 
-:unit a owl:DatatypeProperty ;
-    rdfs:subPropertyOf xsd:nonNegativeInteger ;
+:Unit a rdfs:Class ;
+    rdfs:subClassOf rdfs:Datatype ;
     rdfs:comment "A datatype unit to measure the size of digital information."@en ;
     rdfs:isDefinedBy <> ;
-    rdfs:label "unit"@en .
+    rdfs:label "Unit"@en .
 
 
-:byte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Byte a :Unit
     rdfs:comment "A byte datatype to set the multiple of bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "byte"@en .
 
-:kilobyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Kilobyte a :Unit
     rdfs:comment "A kilobyte (kB) datatype to set the multiple of 1000 * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "kB"@en .
 
-:megabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Megabyte a :Unit
     rdfs:comment "A megabyte (MB) datatype to set the multiple of 1000² * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "MB"@en .
 
-:gigabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Gigabyte a :Unit
     rdfs:comment "A gigabyte (GB) datatype to set the multiple of 1000³ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "GB"@en .
 
-:terabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Terabyte a :Unit
     rdfs:comment "A terabyte (TB) datatype to set the multiple of 1000⁴ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "TB"@en .
 
-:petabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Petabyte a :Unit
     rdfs:comment "A petabyte (PB) datatype to set the multiple of 1000⁵ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "PB"@en .
 
-:exabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Exabyte a :Unit
     rdfs:comment "A exabyte (EB) datatype to set the multiple of 1000⁶ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "EB"@en .
 
-:zettabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Zettabyte a :Unit
     rdfs:comment "A zettabyte (ZB) datatype to set the multiple of 1000⁷ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "ZB"@en .
 
-:yottabyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Yottabyte a :Unit
     rdfs:comment "A yottabyte (YB) datatype to set the multiple of 1000⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YB"@en .
 
 
 
-:kibibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Kibibyte a :Unit
     rdfs:comment "A kibibyte (kiB) datatype to set the multiple of 1024 * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "kiB"@en .
 
-:mebibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Mebibyte a :Unit
     rdfs:comment "A mebibyte (MiB) datatype to set the multiple of 1024² * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "MiB"@en .
 
 
-:gibibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Gibibyte a :Unit
     rdfs:comment "A gibibyte (GiB) datatype to set the multiple of 1024³ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "GiB"@en .
 
-:tebibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Tebibyte a :Unit
     rdfs:comment "A tebibyte (TiB) datatype to set the multiple of 1024⁴ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "TiB"@en .
 
-:pebibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Pebibyte a :Unit
     rdfs:comment "A pebibyte (PiB) datatype to set the multiple of 1024⁵ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "PiB"@en .
 
-:exbibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Exbibyte a :Unit
     rdfs:comment "A exbibyte (EiB) datatype to set the multiple of 1024⁶ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "EiB"@en .
 
-:zebibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Zebibyte a :Unit
     rdfs:comment "A zebibyte (ZiB) datatype to set the multiple of 1024⁷ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "ZiB"@en .
 
-:yobibyte a owl:DatatypeProperty ;
-    rdfs:subPropertyOf :unit ;
+:Yobibyte a :Unit
     rdfs:comment "A yobibyte (YiB) datatype to set the multiple of 1024⁸ * bytes."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:label "YiB"@en .


### PR DESCRIPTION
Since I would need an ontology/vocabulary if we were to go with the first alternative of #29 , I decided to sit down and draft one.

Units are a little bit awkward in RDF, I feel, so it is a bit hackish to do it this way, but I think it simplifies things greatly, as evident by the example in #29, where many more triples were needed.

Does this look reasonable? Could we have an ns URI for it?