### PR TITLE
Added storageUsage

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -202,4 +202,11 @@
     rdfs:isDefinedBy <> ;
     rdfs:domain :Account ;
     rdfs:label "Non-volatile memory quota"@en .
-    
+
+:storageUsage
+    a rdf:Property, owl:DatatypeProperty ;
+    rdfs:comment "The amount of non-volatile memory that the user have used"@en ;
+    rdfs:isDefinedBy <> ;
+    rdfs:domain :Account ;
+    rdfs:label "Non-volatile memory usage"@en .
+

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -198,14 +198,14 @@
 
 :storageQuota
     a rdf:Property, owl:DatatypeProperty ;
-    rdfs:comment "The quota of non-volatile memory that the user may use"@en ;
+    rdfs:comment "The quota of non-volatile memory that is available for the account (in bytes)"@en ;
     rdfs:isDefinedBy <> ;
     rdfs:domain :Account ;
     rdfs:label "Non-volatile memory quota"@en .
 
 :storageUsage
     a rdf:Property, owl:DatatypeProperty ;
-    rdfs:comment "The amount of non-volatile memory that the user have used"@en ;
+    rdfs:comment "The amount of non-volatile memory that the account have used (in bytes)"@en ;
     rdfs:isDefinedBy <> ;
     rdfs:domain :Account ;
     rdfs:label "Non-volatile memory usage"@en .


### PR DESCRIPTION
Based on discussion in https://github.com/solid/vocab/issues/37 and implementation in https://github.com/solid/node-solid-server/pull/1060

I propose the use of `storageUsage` to indicate the total size of resources residing in a specific storage.