### PR TITLE
Editorial changes

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -22,6 +22,7 @@ prefix vann: <http://purl.org/vocab/vann/>
 ## Ontology
 <http://www.w3.org/ns/solid/terms>
     a owl:Ontology ;
+    dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     rdfs:label "Solid Terms ontology"@en ;
     rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -15,22 +15,7 @@ prefix vann: <http://purl.org/vocab/vann/>
     rdfs:comment "The Solid Terms vocabulary defines terms used in the Solid API specifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     dc:issued "2015-11-16"^^xsd:date ;
-    dc:modified "2015-12-18"^^xsd:date ;
-    dc:modified "2015-12-20"^^xsd:date ;
-    dc:modified "2016-01-04"^^xsd:date ;
-    dc:modified "2016-02-05"^^xsd:date ;
-    dc:modified "2016-03-11"^^xsd:date ;
-    dc:modified "2016-05-17"^^xsd:date ;
-    dc:modified "2017-08-15"^^xsd:date ;
-    dc:modified "2017-08-16"^^xsd:date ;
-    dc:modified "2017-08-17"^^xsd:date ;
-    dc:modified "2018-01-24"^^xsd:date ;
-    dc:modified "2018-10-24"^^xsd:date ;
-    dc:modified "2018-10-25"^^xsd:date ;
-    dc:modified "2018-10-26"^^xsd:date ;
-    dc:modified "2018-11-07"^^xsd:date ;
-    dc:modified "2019-01-22"^^xsd:date ;
-    dc:modified "2020-12-17"^^xsd:date ;
+    dc:modified "2020-12-22"^^xsd:date ;
     vann:preferredNamespacePrefix "solid" ;
     vann:preferredNamespaceUri "http://www.w3.org/ns/solid/terms#"^^xsd:anyURI .
 

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -190,7 +190,7 @@ solid:oidcIssuer
     dc:modified "2017-08-16"^^xsd:date ;
     rdfs:comment "The preferred OpenID Connect issuer URI for a given Web ID."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
-    rdfs:label "oidc issuer"@en ;
+    rdfs:label "OIDC issuer"@en ;
     rdfs:subPropertyOf <http://openid.net/specs/connect/1.0/issuer> .
 
 solid:patches

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -11,7 +11,7 @@ prefix vann: <http://purl.org/vocab/vann/>
 <http://www.w3.org/ns/solid/terms>
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-    rdfs:label "Solid Terms ontology"@en ;
+    rdfs:label "Solid Terms"@en ;
     rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     dc:issued "2015-11-16"^^xsd:date ;

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -1,25 +1,13 @@
-# See details within this document for linkage to specification and purpose.
-# This ontology file is a non-normative supporting document.
-
-# Solid terms ontology
-
-## Ontology preferred namespace prefix and URI
 prefix solid: <http://www.w3.org/ns/solid/terms#>
-
-## Other namespaces used
-### Core W3C ontologies (OWL 2 reserved vocabulary)
 prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 prefix owl: <http://www.w3.org/2002/07/owl#>
 prefix xsd: <http://www.w3.org/2001/XMLSchema#>
-### Other ontologies
 prefix dc: <http://purl.org/dc/terms/>
 prefix ldp: <http://www.w3.org/ns/ldp#>
 prefix log: <http://www.w3.org/2000/10/swap/log#>
 prefix vann: <http://purl.org/vocab/vann/>
 
-
-## Ontology
 <http://www.w3.org/ns/solid/terms>
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -12,7 +12,7 @@ prefix vann: <http://purl.org/vocab/vann/>
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     rdfs:label "Solid Terms"@en ;
-    rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
+    rdfs:comment "The Solid Terms vocabulary defines terms used in the Solid API specifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     dc:issued "2015-11-16"^^xsd:date ;
     dc:modified "2015-12-18"^^xsd:date ;

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -177,7 +177,7 @@ solid:oidcIssuer
     a rdf:Property ;
     dc:issued "2017-08-15"^^xsd:date ;
     dc:modified "2017-08-16"^^xsd:date ;
-    rdfs:comment "The preferred OpenID Connect issuer URI for a given Web ID."@en ;
+    rdfs:comment "The preferred OpenID Connect issuer URI for a given WebID."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "OIDC issuer"@en ;
     rdfs:subPropertyOf <http://openid.net/specs/connect/1.0/issuer> .

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -228,7 +228,7 @@ solid:publicTypeIndex
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:subPropertyOf solid:typeIndex ;
     rdfs:comment "Points to a listed type index resource."@en ;
-    rdfs:range <#ListedDocument> ;
+    rdfs:range solid:ListedDocument ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "public type index"@en .
 

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -8,12 +8,12 @@ prefix ldp: <http://www.w3.org/ns/ldp#>
 prefix log: <http://www.w3.org/2000/10/swap/log#>
 prefix vann: <http://purl.org/vocab/vann/>
 
-<http://www.w3.org/ns/solid/terms>
+<http://www.w3.org/ns/solid/terms#>
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     rdfs:label "Solid Terms"@en ;
     rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     dc:issued "2015-11-16"^^xsd:date ;
     dc:modified "2015-12-18"^^xsd:date ;
     dc:modified "2015-12-20"^^xsd:date ;
@@ -39,7 +39,7 @@ solid:Account
     a rdfs:Class ;
     dc:issued "2016-05-17"^^xsd:date ;
     rdfs:comment "A Solid account."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Account"@en .
 
 solid:Inbox
@@ -47,7 +47,7 @@ solid:Inbox
     dc:issued "2015-11-16"^^xsd:date ;
     dc:modified "2018-10-24"^^xsd:date ;
     rdfs:comment "A resource containing notifications."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Inbox"@en .
 
 solid:ListedDocument
@@ -55,7 +55,7 @@ solid:ListedDocument
     dc:issued "2015-11-16"^^xsd:date ;
     dc:modified "2018-01-24"^^xsd:date ;
     rdfs:comment "Listed Type Index is a registry of resources that are publicly discoverable by outside users and applications."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Listed Type Index"@en .
 
 solid:Notification
@@ -64,42 +64,42 @@ solid:Notification
     dc:modified "2015-12-20"^^xsd:date ;
     dc:modified "2018-10-25"^^xsd:date ;
     rdfs:comment "A notification resource."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Notification"@en .
 
 solid:Patch
     a rdfs:Class ;
     dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "A patch expresses conditional modifications to a resource that has an RDF-based representation."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Patch"@en .
 
 solid:Timeline
     a rdfs:Class ;
     dc:issued "2016-01-04"^^xsd:date ;
     rdfs:comment "A resource containing time ordered items and sub-containers.  Sub-containers may be desirable in file based systems to split the timeline into logical components e.g. /yyyy-mm-dd/ as used in ISO 8061."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Timeline"@en .
 
 solid:TypeIndex
     a rdfs:Class ;
     dc:issued "2016-02-05"^^xsd:date ;
     rdfs:comment "A index of type registries for resources. Applications can register the RDF type they use and list them in the index resource."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Type index"@en .
 
 solid:TypeRegistration
     a rdfs:Class ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "The registered types that map a RDF classes/types to their locations using either `instance` or `instanceContainer` property."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Type Registration"@en .
 
 solid:UnlistedDocument
     a rdfs:Class ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Unlisted Type Index is a registry of resources that are private to the user and their apps, for types that are not publicly discoverable."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "Unlisted Type Index"@en .
 
 ### Properties
@@ -108,14 +108,14 @@ solid:account
     dc:issued "2016-05-17"^^xsd:date ;
     dc:modified "2018-01-24"^^xsd:date ;
     rdfs:comment "A solid account belonging to an Agent."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "account"@en .
 
 solid:deletes
     a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
     dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The triple patterns this patch removes from the document."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "deletes"@en ;
     rdfs:domain solid:Patch ;
     rdfs:range log:Formula .
@@ -124,7 +124,7 @@ solid:forClass
     a rdf:Property ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "A class that is used to map an listed or unlisted type index."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "registry class"@en .
 
 solid:inbox
@@ -136,14 +136,14 @@ solid:inbox
     owl:equivalentProperty ldp:inbox ;
     rdfs:subPropertyOf ldp:inbox ;
     rdfs:comment "Deprecated pointer to a Linked Data Notifications inbox; please use http://www.w3.org/ns/ldp#inbox instead."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "inbox (deprecated)"@en .
 
 solid:inserts
     a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
     dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The triple patterns this patch adds to the document."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "inserts"@en ;
     rdfs:domain solid:Patch ;
     rdfs:range log:Formula .
@@ -152,28 +152,28 @@ solid:instance
     a rdf:Property ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Maps a type to an individual resource, typically an index or a directory listing resource."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "instance"@en .
 
 solid:instanceContainer
     a rdf:Property ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Maps a type to a container which the client would have to list to get the instances of that type."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "instance container"@en .
 
 solid:loginEndpoint
     a rdf:Property ;
     dc:issued "2015-11-16"^^xsd:date ;
     rdfs:comment "The login URI of a given server."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "loginEndpoint"@en .
 
 solid:logoutEndpoint
     a rdf:Property ;
     dc:issued "2015-11-16"^^xsd:date ;
     rdfs:comment "The logout URI of a given server."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "logoutEndpoint"@en .
 
 solid:notification
@@ -181,7 +181,7 @@ solid:notification
     dc:issued "2016-03-11"^^xsd:date ;
     dc:modified "2018-10-25"^^xsd:date ;
     rdfs:comment "Notification resource for an inbox."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "notification"@en .
 
 solid:oidcIssuer
@@ -189,7 +189,7 @@ solid:oidcIssuer
     dc:issued "2017-08-15"^^xsd:date ;
     dc:modified "2017-08-16"^^xsd:date ;
     rdfs:comment "The preferred OpenID Connect issuer URI for a given Web ID."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "OIDC issuer"@en ;
     rdfs:subPropertyOf <http://openid.net/specs/connect/1.0/issuer> .
 
@@ -197,7 +197,7 @@ solid:patches
     a rdf:Property, owl:ObjectProperty ;
     dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The document to which this patch applies."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "patches"@en ;
     rdfs:domain solid:Patch ;
     rdfs:range rdfs:Resource .
@@ -207,7 +207,7 @@ solid:privateTypeIndex
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Points to an unlisted type index resource."@en ;
     rdfs:range solid:UnlistedDocument ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "private type index"@en .
 
 solid:publicTypeIndex
@@ -216,14 +216,14 @@ solid:publicTypeIndex
     rdfs:subPropertyOf solid:typeIndex ;
     rdfs:comment "Points to a listed type index resource."@en ;
     rdfs:range solid:ListedDocument ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "public type index"@en .
 
 solid:read
     a rdf:Property ;
     dc:issued "2015-12-18"^^xsd:date ;
     rdfs:comment "Indicates if a message has been read or not. This property should have a boolean datatype."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:domain <http://rdfs.org/sioc/ns#Post> ;
     rdfs:label "read"@en .
 
@@ -233,7 +233,7 @@ solid:storageQuota
     dc:modified "2018-11-07"^^xsd:date ;
     dc:modified "2019-01-22"^^xsd:date ;
     rdfs:comment "The quota of non-volatile memory that is available for the account (in bytes)"@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:domain solid:Account ;
     rdfs:label "Non-volatile memory quota"@en .
 
@@ -241,7 +241,7 @@ solid:storageUsage
     a rdf:Property, owl:DatatypeProperty ;
     dc:issued "2019-01-22"^^xsd:date ;
     rdfs:comment "The amount of non-volatile memory that the account have used (in bytes)"@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:domain solid:Account ;
     rdfs:label "Non-volatile memory usage"@en .
 
@@ -250,21 +250,21 @@ solid:typeIndex
     dc:issued "2016-02-05"^^xsd:date ;
     rdfs:comment "Points to a TypeIndex resource."@en ;
     rdfs:range solid:TypeIndex ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "type index"@en .
 
 solid:timeline
     a rdf:Property ;
     dc:issued "2016-01-04"^^xsd:date ;
     rdfs:comment "Timeline for a given resource."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "timeline"@en .
 
 solid:where
     a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
     dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The conditions the document and the inserted and deleted triple patterns need to satisfy in order for the patch to be applied."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "where"@en ;
     rdfs:domain solid:Patch ;
     rdfs:range log:Formula .

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -1,212 +1,283 @@
-@base <http://www.w3.org/ns/solid/terms> .
-@prefix : <#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix cc: <https://creativecommons.org/ns#> .
-@prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix log: <http://www.w3.org/2000/10/swap/log#> .
-@prefix ldp: <http://www.w3.org/ns/ldp#> .
+# See details within this document for linkage to specification and purpose.
+# This ontology file is a non-normative supporting document.
 
-<>
+# Solid terms ontology
+
+## Ontology preferred namespace prefix and URI
+prefix solid: <http://www.w3.org/ns/solid/terms#>
+
+## Other namespaces used
+### Core W3C ontologies (OWL 2 reserved vocabulary)
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+prefix owl: <http://www.w3.org/2002/07/owl#>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+### Other ontologies
+prefix dc: <http://purl.org/dc/terms/>
+prefix ldp: <http://www.w3.org/ns/ldp#>
+prefix log: <http://www.w3.org/2000/10/swap/log#>
+prefix vann: <http://purl.org/vocab/vann/>
+
+
+## Ontology
+<http://www.w3.org/ns/solid/terms>
     a owl:Ontology ;
-    cc:attributionURL <> ;
-    cc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-    dcterms:issued "2015-11-16"^^xsd:date ;
-    dcterms:modified "2018-01-24"^^xsd:date ;
-    rdfs:label "Solid terms"@en .
+    rdfs:label "Solid Terms ontology"@en ;
+    rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:seeAlso
+        <https://solid.github.io/specification/> ;
+    dc:issued "2015-11-16"^^xsd:date ;
+    dc:modified "2015-12-18"^^xsd:date ;
+    dc:modified "2015-12-20"^^xsd:date ;
+    dc:modified "2016-01-04"^^xsd:date ;
+    dc:modified "2016-02-05"^^xsd:date ;
+    dc:modified "2016-03-11"^^xsd:date ;
+    dc:modified "2016-05-17"^^xsd:date ;
+    dc:modified "2017-08-15"^^xsd:date ;
+    dc:modified "2017-08-16"^^xsd:date ;
+    dc:modified "2017-08-17"^^xsd:date ;
+    dc:modified "2018-01-24"^^xsd:date ;
+    dc:modified "2018-10-24"^^xsd:date ;
+    dc:modified "2018-10-25"^^xsd:date ;
+    dc:modified "2018-10-26"^^xsd:date ;
+    dc:modified "2018-11-07"^^xsd:date ;
+    dc:modified "2019-01-22"^^xsd:date ;
+    dc:modified "2020-12-17"^^xsd:date ;
+    vann:preferredNamespacePrefix "solid" ;
+    vann:preferredNamespaceUri "http://www.w3.org/ns/solid/terms#"^^xsd:anyURI .
 
-:Account
+### Classes
+solid:Account
     a rdfs:Class ;
+    dc:issued "2016-05-17"^^xsd:date ;
     rdfs:comment "A Solid account."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Account"@en .
 
-:Inbox
+solid:Inbox
     a rdfs:Class ;
+    dc:issued "2015-11-16"^^xsd:date ;
+    dc:modified "2018-10-24"^^xsd:date ;
     rdfs:comment "A resource containing notifications."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Inbox"@en .
 
-:ListedDocument
+solid:ListedDocument
     a rdfs:Class ;
+    dc:issued "2015-11-16"^^xsd:date ;
+    dc:modified "2018-01-24"^^xsd:date ;
     rdfs:comment "Listed Type Index is a registry of resources that are publicly discoverable by outside users and applications."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Listed Type Index"@en .
 
-:Notification
+solid:Notification
     a rdfs:Class ;
+    dc:issued "2015-12-18"^^xsd:date ;
+    dc:modified "2015-12-20"^^xsd:date ;
+    dc:modified "2018-10-25"^^xsd:date ;
     rdfs:comment "A notification resource."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Notification"@en .
 
-:Patch
+solid:Patch
     a rdfs:Class ;
+    dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "A patch expresses conditional modifications to a resource that has an RDF-based representation."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Patch"@en .
 
-:Timeline
+solid:Timeline
     a rdfs:Class ;
+    dc:issued "2016-01-04"^^xsd:date ;
     rdfs:comment "A resource containing time ordered items and sub-containers.  Sub-containers may be desirable in file based systems to split the timeline into logical components e.g. /yyyy-mm-dd/ as used in ISO 8061."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Timeline"@en .
 
-:TypeIndex
+solid:TypeIndex
     a rdfs:Class ;
+    dc:issued "2016-02-05"^^xsd:date ;
     rdfs:comment "A index of type registries for resources. Applications can register the RDF type they use and list them in the index resource."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Type index"@en .
 
-:TypeRegistration
+solid:TypeRegistration
     a rdfs:Class ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "The registered types that map a RDF classes/types to their locations using either `instance` or `instanceContainer` property."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Type Registration"@en .
 
-:UnlistedDocument
+solid:UnlistedDocument
     a rdfs:Class ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Unlisted Type Index is a registry of resources that are private to the user and their apps, for types that are not publicly discoverable."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "Unlisted Type Index"@en .
 
-:account
+### Properties
+solid:account
     a rdf:Property ;
+    dc:issued "2016-05-17"^^xsd:date ;
+    dc:modified "2018-01-24"^^xsd:date ;
     rdfs:comment "A solid account belonging to an Agent."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "account"@en .
 
-:deletes
+solid:deletes
     a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
+    dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The triple patterns this patch removes from the document."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "deletes"@en ;
-    rdfs:domain :Patch ;
+    rdfs:domain solid:Patch ;
     rdfs:range log:Formula .
 
-:forClass
+solid:forClass
     a rdf:Property ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "A class that is used to map an listed or unlisted type index."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "registry class"@en .
 
-:inbox
-    a rdf:Property ;
+solid:inbox
     owl:deprecated true ;
-    owl:equivalentProperty ldp:inbox;
-    rdfs:subPropertyOf ldp:inbox;
+    a rdf:Property ;
+    dc:issued "2015-11-16"^^xsd:date ;
+    dc:modified "2016-02-05"^^xsd:date ;
+    dc:modified "2018-10-25"^^xsd:date ;
+    owl:equivalentProperty ldp:inbox ;
+    rdfs:subPropertyOf ldp:inbox ;
     rdfs:comment "Deprecated pointer to a Linked Data Notifications inbox; please use http://www.w3.org/ns/ldp#inbox instead."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "inbox (deprecated)"@en .
 
-:inserts
+solid:inserts
     a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
+    dc:issued "2017-08-17"^^xsd:date ;
     rdfs:comment "The triple patterns this patch adds to the document."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "inserts"@en ;
-    rdfs:domain :Patch ;
+    rdfs:domain solid:Patch ;
     rdfs:range log:Formula .
 
-:instance
+solid:instance
     a rdf:Property ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Maps a type to an individual resource, typically an index or a directory listing resource."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "instance"@en .
 
-:instanceContainer
+solid:instanceContainer
     a rdf:Property ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Maps a type to a container which the client would have to list to get the instances of that type."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "instance container"@en .
 
-:loginEndpoint
+solid:loginEndpoint
     a rdf:Property ;
+    dc:issued "2015-11-16"^^xsd:date ;
     rdfs:comment "The login URI of a given server."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "loginEndpoint"@en .
 
-:logoutEndpoint
+solid:logoutEndpoint
     a rdf:Property ;
+    dc:issued "2015-11-16"^^xsd:date ;
     rdfs:comment "The logout URI of a given server."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "logoutEndpoint"@en .
 
-:notification
+solid:notification
     a rdf:Property ;
+    dc:issued "2016-03-11"^^xsd:date ;
+    dc:modified "2018-10-25"^^xsd:date ;
     rdfs:comment "Notification resource for an inbox."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "notification"@en .
 
-:privateTypeIndex
+solid:oidcIssuer
     a rdf:Property ;
+    dc:issued "2017-08-15"^^xsd:date ;
+    dc:modified "2017-08-16"^^xsd:date ;
+    rdfs:comment "The preferred OpenID Connect issuer URI for a given Web ID."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:label "oidc issuer"@en ;
+    rdfs:subPropertyOf <http://openid.net/specs/connect/1.0/issuer> .
+
+solid:patches
+    a rdf:Property, owl:ObjectProperty ;
+    dc:issued "2017-08-17"^^xsd:date ;
+    rdfs:comment "The document to which this patch applies."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:label "patches"@en ;
+    rdfs:domain solid:Patch ;
+    rdfs:range rdfs:Resource .
+
+solid:privateTypeIndex
+    a rdf:Property ;
+    dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Points to an unlisted type index resource."@en ;
     rdfs:range <#UnlistedDocument> ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "private type index"@en .
 
-:publicTypeIndex
+solid:publicTypeIndex
     a rdf:Property ;
-    rdfs:subPropertyOf :typeIndex ;
+    dc:issued "2018-01-24"^^xsd:date ;
+    rdfs:subPropertyOf solid:typeIndex ;
     rdfs:comment "Points to a listed type index resource."@en ;
     rdfs:range <#ListedDocument> ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "public type index"@en .
 
-:read
+solid:read
     a rdf:Property ;
+    dc:issued "2015-12-18"^^xsd:date ;
     rdfs:comment "Indicates if a message has been read or not. This property should have a boolean datatype."@en ;
-    rdfs:isDefinedBy <> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:domain <http://rdfs.org/sioc/ns#Post> ;
     rdfs:label "read"@en .
 
-:typeIndex
-    a rdf:Property ;
-    rdfs:comment "Points to a TypeIndex resource."@en ;
-    rdfs:range <#TypeIndex> ;
-    rdfs:isDefinedBy <> ;
-    rdfs:label "type index"@en .
-
-:oidcIssuer
-    a rdf:Property ;
-    rdfs:comment "The preferred OpenID Connect issuer URI for a given Web ID."@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:label "oidcIssuer"@en ;
-    rdfs:subPropertyOf <http://openid.net/specs/connect/1.0/issuer> .
-
-:patches
-    a rdf:Property, owl:ObjectProperty ;
-    rdfs:comment "The document to which this patch applies."@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:label "patches"@en ;
-    rdfs:domain :Patch ;
-    rdfs:range rdfs:Resource .
-
-:timeline
-    a rdf:Property ;
-    rdfs:comment "Timeline for a given resource."@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:label "timeline"@en .
-
-:where
-    a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
-    rdfs:comment "The conditions the document and the inserted and deleted triple patterns need to satisfy in order for the patch to be applied."@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:label "where"@en ;
-    rdfs:domain :Patch ;
-    rdfs:range log:Formula .
-
-:storageQuota
+solid:storageQuota
     a rdf:Property, owl:DatatypeProperty ;
+    dc:issued "2018-10-26"^^xsd:date ;
+    dc:modified "2018-11-07"^^xsd:date ;
+    dc:modified "2019-01-22"^^xsd:date ;
     rdfs:comment "The quota of non-volatile memory that is available for the account (in bytes)"@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:domain :Account ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:domain solid:Account ;
     rdfs:label "Non-volatile memory quota"@en .
 
-:storageUsage
+solid:storageUsage
     a rdf:Property, owl:DatatypeProperty ;
+    dc:issued "2019-01-22"^^xsd:date ;
     rdfs:comment "The amount of non-volatile memory that the account have used (in bytes)"@en ;
-    rdfs:isDefinedBy <> ;
-    rdfs:domain :Account ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:domain solid:Account ;
     rdfs:label "Non-volatile memory usage"@en .
 
+solid:typeIndex
+    a rdf:Property ;
+    dc:issued "2016-02-05"^^xsd:date ;
+    rdfs:comment "Points to a TypeIndex resource."@en ;
+    rdfs:range <#TypeIndex> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:label "type index"@en .
+
+solid:timeline
+    a rdf:Property ;
+    dc:issued "2016-01-04"^^xsd:date ;
+    rdfs:comment "Timeline for a given resource."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:label "timeline"@en .
+
+solid:where
+    a rdf:Property, owl:ObjectProperty, owl:FunctionalProperty ;
+    dc:issued "2017-08-17"^^xsd:date ;
+    rdfs:comment "The conditions the document and the inserted and deleted triple patterns need to satisfy in order for the patch to be applied."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
+    rdfs:label "where"@en ;
+    rdfs:domain solid:Patch ;
+    rdfs:range log:Formula .

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -219,7 +219,7 @@ solid:privateTypeIndex
     a rdf:Property ;
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Points to an unlisted type index resource."@en ;
-    rdfs:range <#UnlistedDocument> ;
+    rdfs:range solid:UnlistedDocument ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "private type index"@en .
 

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -262,7 +262,7 @@ solid:typeIndex
     a rdf:Property ;
     dc:issued "2016-02-05"^^xsd:date ;
     rdfs:comment "Points to a TypeIndex resource."@en ;
-    rdfs:range <#TypeIndex> ;
+    rdfs:range solid:TypeIndex ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
     rdfs:label "type index"@en .
 

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -15,7 +15,11 @@ prefix vann: <http://purl.org/vocab/vann/>
     rdfs:comment "The Solid Terms vocabulary defines terms used in the Solid API specifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     dc:issued "2015-11-16"^^xsd:date ;
-    dc:modified "2020-12-22"^^xsd:date ;
+    owl:versionInfo [
+            dc:date "2020-12-22"^^xsd:date ;
+            dc:replaces <https://raw.githubusercontent.com/solid/vocab/387df145ef39936120b25b48891315fe53cb4d91/solid-terms.ttl> ;
+            rdfs:seeAlso <https://github.com/solid/vocab/pull/46> ;
+        ] ;
     vann:preferredNamespacePrefix "solid" ;
     vann:preferredNamespaceUri "http://www.w3.org/ns/solid/terms#"^^xsd:anyURI .
 

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -12,7 +12,7 @@ prefix vann: <http://purl.org/vocab/vann/>
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     rdfs:label "Solid Terms"@en ;
-    rdfs:comment "The Solid Terms vocabulary defines terms used in the Solid API specifications."@en ;
+    rdfs:comment "The Solid Terms vocabulary defines terms referenced in Solid specifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     dc:issued "2015-11-16"^^xsd:date ;
     owl:versionInfo [

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -25,8 +25,6 @@ prefix vann: <http://purl.org/vocab/vann/>
     rdfs:label "Solid Terms ontology"@en ;
     rdfs:comment "Solid, derived from social linked data, is a proposed set of conventions and tools for building decentralized social applications based on Linked Data principles."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms> ;
-    rdfs:seeAlso
-        <https://solid.github.io/specification/> ;
     dc:issued "2015-11-16"^^xsd:date ;
     dc:modified "2015-12-18"^^xsd:date ;
     dc:modified "2015-12-20"^^xsd:date ;


### PR DESCRIPTION
This pull request suggests editorial changes that correspond to a set of conventions for turtle documents:
- Define prefixes using the SPARQL compatible syntax. See also: [Turtle 1.1 Spec IRIs Note](https://www.w3.org/TR/turtle/#sec-iri). I believe the RDF 1.1 Turtle parsers should be considered widely deployed.
- Section comments: Prefixes, Ontology, Classes and Properties.
- Alphabetical ordering within sections.
- Defined prefferred ontology prefix and URI using vann.
- Link the ontology to the specification(s) using rdfs:seeAlso.
- Link everything that the ontology defines, including itself to the ontology using rdfs:isDefinedBy.
- Use of dc:issued and dc:modified to reflect the evolution of the ontology.