### PR TITLE
Fix syntax error and add testScript

### DIFF
--- a/spec.ttl
+++ b/spec.ttl
@@ -56,9 +56,13 @@ spec:requirementLevel
   rdfs:domain spec:Requirement .
 
 spec:requirementSubject
-  a rdf:Property ; owl:ObjectProperty ;
+  a rdf:Property, owl:ObjectProperty ;
   rdfs:label "requirement subject"@en ;
   rdfs:domain spec:Requirement .
+
+spec:testScript
+  a rdf:Property , owl:ObjectProperty ;
+  rdfs:label "test script"@en .
 
 ### XXX: Experimental
 #spec:NormativeRequirement

--- a/spec.ttl
+++ b/spec.ttl
@@ -61,8 +61,9 @@ spec:requirementSubject
   rdfs:domain spec:Requirement .
 
 spec:testScript
-  a rdf:Property , owl:ObjectProperty ;
-  rdfs:label "test script"@en .
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "test script"@en ;
+  rdfs:domain test-description:TestCase .
 
 ### XXX: Experimental
 #spec:NormativeRequirement


### PR DESCRIPTION
There was a typo in spec:requirementSubject and we need spec:testScript to reference the script used to test a requirement.