### PR TITLE
Add Basic Access Control ontology

### DIFF
--- a/acl.n3
+++ b/acl.n3
@@ -1,0 +1,182 @@
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix gen: <http://www.w3.org/2006/gen/ont#>.
+@prefix foaf: <http://xmlns.com/foaf/0.1/>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vcard: <http://www.w3.org/2006/vcard/ns#>.
+
+@keywords is, a, of.
+@prefix : <http://www.w3.org/ns/auth/acl#>.
+
+
+<> dc:title "Basic Access Control ontology";
+    rdfs:comment """Defines the class Authorization and its essential properties,
+    and also some classes of access such as read and write. """.
+
+<https://www.w3.org/wiki/WebAccessControl> dc:describes <>.
+<https://github.com/solid/web-access-control-spec> dc:describes <>.
+
+
+Authorization a rdfs:Class;
+    rdfs:label  "authorization";
+    rdfs:comment """An element of access control,
+    allowing agent to agents access of some kind to resources or classes of resources""".
+
+agent   a rdf:Property;
+        rdfs:label "agent";
+        rdfs:comment "A person or social entity to being given the right";
+        rdfs:domain     Authorization;
+        rdfs:range      foaf:Agent.
+
+origin   a rdf:Property;
+        rdfs:label "origin";
+        rdfs:comment """A web application, identified by its Origin, such as
+        <https://scripts.example.com>, being given the right.
+        When a user of the web application at a certain origin accesses the server,
+        then the browser sets the Origin: header to warn that a possibly untrusted webapp
+        is being used.
+        Then, BOTH the user AND the origin must have the required access.""";
+        rdfs:seeAlso <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>;
+        rdfs:domain     Authorization;
+        rdfs:range      Origin.
+
+agentClass   a rdf:Property;
+        rdfs:label "agent class";
+        rdfs:comment "A class of persons or social entities to being given the right";
+        rdfs:domain     Authorization;
+        rdfs:range      rdfs:Class.  # Typically be subclass of foaf:Agent.
+                        # For public access, use foaf:Agent.
+
+AuthenticatedAgent a rdfs:Class;
+        rdfs:subClassOf foaf:Agent;
+        rdfs:label "Anyone authenticated";
+        rdfs:comment """A class of agents who have been authenticated.
+In other words, anyone can access this resource, but not anonymously.
+The social expectation is that the authentication process will provide an
+identify and a name, or pseudonym.
+(A new ID should not be minted for every access: the intent is that the user
+is able to continue to use the ID for continues interactions with peers,
+and for example to develop a reputation)
+""" .
+
+agentGroup a rdf:Property;
+          rdfs:label "agent group";
+          rdfs:comment """A group of persons or social entities to being given the right.
+          The right is given to any entity which is a vcard:member of the group,
+          as defined by the document received when the Group is dereferenced.""";
+          rdfs:domain     Authorization;
+          rdfs:range      vcard:Group.  # Must be subclass of foaf:Agent.
+                          # For public access, use foaf:Agent.
+
+accessTo
+    a rdf:Property;
+        rdfs:label "to";
+        rdfs:comment "The information resource to which access is being granted.";
+        rdfs:domain     Authorization;
+        rdfs:range      gen:InformationResource.
+
+accessToClass
+    a rdf:Property;
+        rdfs:label "to all in";
+        rdfs:comment "A class of information resources to which access is being granted.";
+        rdfs:domain     Authorization;
+        rdfs:range      rdfs:Class.
+
+default
+    a rdf:Property;
+        rdfs:label "default access for things in this";
+        rdfs:comment """If a resource has no ACL file (it is 404),
+        then access to the resource if given by the ACL of the immediately
+        containing directory, or failing that (404) the ACL of the recursively next
+        containing directory which has an ACL file.
+        Within that ACL file,
+        any Authentication which has that directory as its acl:default applies to the
+        resource. (The highest directory must have an ACL file.)
+""";
+        rdfs:domain     Authorization.
+
+defaultForNew
+    a rdf:Property;
+        rdfs:label "default access for new things in the object";
+        rdfs:comment """THIS IS OBSOLETE AS OF 2017-08-01.   See 'default'.
+        Was: A directory for which this authorization is used for new files in the directory.""";
+        rdfs:domain     Authorization.
+
+mode
+    a rdf:Property;
+        rdfs:label "access mode";
+        rdfs:comment "A mode of access such as read or write.";
+        rdfs:domain     Authorization;
+        rdfs:range      rdfs:Class.
+
+#################################### Origins
+
+Origin a rdfs:Class;
+        rdfs:label "Origin";
+        rdfs:seeAlso <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin>;
+        rdfs:comment """An Origin is basically a web site
+        (Note WITHOUT the trailing slash after the domain name and port in its URI)
+        and is the basis for controlling access to data by web apps
+        in the Same Origin Model of web security.
+        All scripts from the same origin are given the same right.""".
+
+#################################### Access modes
+
+Access a rdfs:Class;
+    label "access"@en;
+    rdfs:comment """Any kind of access to a resource. Don't use this, use R W and RW""".
+
+Read a rdfs:Class;
+    rdfs:label  "read"@en;
+    rdfs:subClassOf Access;
+    rdfs:comment    """The class of read operations""".
+
+Write a rdfs:Class;
+    rdfs:subClassOf Access;
+    rdfs:label  "write"@en.
+
+Append a rdfs:Class;
+    rdfs:subClassOf Access, Write;
+    rdfs:label  "append"@en;
+    rdfs:comment """Append accesses are specific write access which only add information, and do not remove information.
+    For text files, for example, append access allows bytes to be added onto the end of the file.
+    For RDF graphs, Append access allows adds triples to the graph but does not remove any.
+    Append access is useful for dropbox functionality.
+    Dropbox can be used for link notification, which the information added is a notification
+    that a some link has been made elsewhere relevant to the given resource.
+    """.
+
+Control a rdfs:Class;
+    rdfs:subClassOf Access;
+    rdfs:label  "control"@en;
+    rdfs:comment """Allows read/write access to the ACL for the resource(s)""".
+
+
+# Linking a resource to its access control information
+accessControl
+    a rdf:Property;
+        rdfs:label "access control";
+        rdfs:subPropertyOf rdfs:seeAlso;
+        rdfs:comment """The Access Control file for this information resource.
+        This may of course be a virtual resource implemented by the access control system.
+        Note also HTTP's header  Link:  foo.meta ;rel=meta can be used for this.""";
+        rdfs:domain      gen:InformationResource;
+        rdfs:range      gen:InformationResource.
+
+######################## Ownership
+
+owner a rdf:Property;
+    rdfs:label "owner"@en;
+    rdfs:range foaf:Agent;
+    rdfs:comment """The person or other agent which owns this.
+    For example, the owner of a file in a filesystem.
+    There is a sense of right to control.   Typically defaults to the agent who craeted
+    something but can be changed.""".
+
+delegates a rdf:Property;
+    rdfs:label "delegates"@en;
+    rdfs:range foaf:Agent;
+    rdfs:comment """Delegates a person or another agent to act on behalf of the agent.
+    For example, Alice delegates Bob to act on behalf of Alice for ACL purposes.""".
+
+# ENDS


### PR DESCRIPTION
Copying the ACL ontology here so that we can process updates through this repository.

I presume N3 serialization is the source. The acl.n3 in this PR is from the output of:

```
curl -H'Accept: text/n3' http://www.w3.org/ns/auth/acl
```

If the copy in the version control system at w3.org is different, we can update the PR.