### PR TITLE
Use 'public' not 'listed' in comments. Implement Boolean range for  .

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,6 @@
+Copyright 2019 - present
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+
+alcs:
+		cp acl.n3 ../../../www.w3.org/ns/auth
+
+space:
+		cp space.n3 ../../../www.w3.org/ns/pim/
+	  (cd ../../../www.w3.org/ns/pim/; make space.*)

--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -112,16 +112,25 @@
 
 :privateTypeIndex
     a rdf:Property ;
-    rdfs:comment "Points to an unlisted type index resource."@en ;
-    rdfs:range <#UnlistedDocument> ;
+    rdfs:comment
+    """The object is  to a private (unlisted) type index resource..
+    The subject is the user's webid.
+    The triple in found in the private preferences file.
+    (which itself is pointed to from the public profile by space:preferencesFile)
+    """@en ;
+    rdfs:range :UnlistedDocument ;
     rdfs:isDefinedBy <> ;
     rdfs:label "private type index"@en .
 
 :publicTypeIndex
     a rdf:Property ;
     rdfs:subPropertyOf :typeIndex ;
-    rdfs:comment "Points to a listed type index resource."@en ;
-    rdfs:range <#ListedDocument> ;
+    rdfs:comment """The object is  to a pubic ("listed") type index resource..
+    The subject is the user's webid.
+    The triple in found in the private preferences file.
+    (which itself is pointed to from the public profile by space:preferencesFile)
+    """@en ;
+    rdfs:range :ListedDocument ;
     rdfs:isDefinedBy <> ;
     rdfs:label "public type index"@en .
 
@@ -130,6 +139,7 @@
     rdfs:comment "Indicates if a message has been read or not. This property should have a boolean datatype."@en ;
     rdfs:isDefinedBy <> ;
     rdfs:domain <http://rdfs.org/sioc/ns#Post> ;
+    rdfs:range xsd:boolean;
     rdfs:label "read"@en .
 
 :typeIndex


### PR DESCRIPTION
Trying to phase out "Listed" and "Unlisted" as words for "Public" and "Private".

Implement a range statement which was already in the comments.

