### PR TITLE
spec:requirement as a pointer to a definitions

### DIFF
--- a/spec.ttl
+++ b/spec.ttl
@@ -43,7 +43,6 @@ spec:Specification
 
 spec:requirement
   a rdf:Property, owl:ObjectProperty ;
-  rdfs:subPropertyOf rdfs:isDefinedBy ;
   rdfs:label "requirement"@en ;
   rdfs:range spec:Requirement .
 
@@ -103,7 +102,8 @@ spec:acknowledgements
   rdfs:label "acknowledgements"@en .
 
 spec:requirementReference
-  a rdf:Property ;
+  a rdf:Property ;  
+  rdfs:subPropertyOf rdfs:isDefinedBy ;
   rdfs:label "requirement reference"@en ;
   rdfs:domain test-description:SpecificationTestCase ;
   rdfs:range spec:Requirement .

--- a/spec.ttl
+++ b/spec.ttl
@@ -43,6 +43,7 @@ spec:Specification
 
 spec:requirement
   a rdf:Property, owl:ObjectProperty ;
+  rdfs:subPropertyOf rdfs:isDefinedBy ;
   rdfs:label "requirement"@en ;
   rdfs:range spec:Requirement .
 

--- a/spec.ttl
+++ b/spec.ttl
@@ -102,7 +102,7 @@ spec:acknowledgements
   rdfs:label "acknowledgements"@en .
 
 spec:requirementReference
-  a rdf:Property ;  
+  a rdf:Property ;
   rdfs:subPropertyOf rdfs:isDefinedBy ;
   rdfs:label "requirement reference"@en ;
   rdfs:domain test-description:SpecificationTestCase ;


### PR DESCRIPTION
Wouldn't be appropriate to say that the property `spec:requirement` points to a definition of a requirement, and so is a subproperty of `rdfs:isDefinedBy`?