### PR TITLE
Add properties for RP-initiated logout flows in Solid-OIDC

### DIFF
--- a/solid-oidc-context.jsonld
+++ b/solid-oidc-context.jsonld
@@ -32,6 +32,14 @@
         "@set"
       ]
     },
+    "post_logout_redirect_uris": {
+      "@id": "oidc:post_logout_redirect_uris",
+      "@type": "@id",
+      "@container": [
+        "@id",
+        "@set"
+      ]
+    },
     "require_auth_time": {
       "@id": "oidc:require_auth_time",
       "@type": "xsd:boolean"

--- a/solid-oidc.ttl
+++ b/solid-oidc.ttl
@@ -81,6 +81,13 @@ oidc:redirect_uris
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/oidc#> ;
     vs:term_status "testing" .
 
+oidc:post_logout_redirect_uris
+    a rdf:Property ;
+    rdfs:label "post-logout redirect URIs"@en ;
+    rdfs:comment "A collection of registered URIs used by the client for redirection after logging out"@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/oidc#> ;
+    vs:term_status "testing" .
+
 oidc:require_auth_time
     a rdf:Property ;
     rdfs:label "require auth time"@en ;


### PR DESCRIPTION
For Solid-OIDC implementations that also support [RP-initiated logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), the `post_logout_redirect_uris` property is needed.

This PR adds support for this property in the `oidc` vocabulary and the corresponding JSON-LD context.