### PR TITLE
Add CRDT vocab

### DIFF
--- a/solid-crdt.ttl
+++ b/solid-crdt.ttl
@@ -76,6 +76,7 @@
     a rdfs:Class ;
     rdfs:label "Tombstone"@en ;
     dc:description "Metadata left behind for a resource that has been deleted."@en ;
+    rdfs:subClassOf :Metadata ;
     rdfs:isDefinedBy : .
 
 :resource
@@ -84,7 +85,7 @@
     dc:description "Resource which the metadata or tombstone makes reference to, or which is affected by the operation."@en ;
     rdfs:subPropertyOf dcmi:subject ;
     rdfs:range rdfs:Resource ;
-    rdfs:domain :Metadata, :Operation, :Tombstone ;
+    rdfs:domain :Metadata, :Operation ;
     rdfs:isDefinedBy : .
 
 :createdAt
@@ -110,7 +111,7 @@
     rdfs:label "deletedAt"@en ;
     dc:description "Time at which the resource was deleted or soft-deleted."@en ;
     rdfs:range xsd:dateTime ;
-    rdfs:domain :Metadata, :Tombstone ;
+    rdfs:domain :Metadata ;
     rdfs:isDefinedBy : .
 
 :property

--- a/solid-crdt.ttl
+++ b/solid-crdt.ttl
@@ -81,7 +81,7 @@
 :resource
     a rdf:Property ;
     rdfs:label "resource"@en ;
-    dc:description "Resource which the metadata or tombstone make reference to, or is affected by the operation."@en ;
+    dc:description "Resource which the metadata or tombstone makes reference to, or which is affected by the operation."@en ;
     rdfs:subPropertyOf dcmi:subject ;
     rdfs:range rdfs:Resource ;
     rdfs:domain :Metadata, :Operation, :Tombstone ;
@@ -99,7 +99,7 @@
 :updatedAt
     a rdf:Property ;
     rdfs:label "updatedAt"@en ;
-    dc:description "Time at which the resource was updated for the last time."@en ;
+    dc:description "Time at which the resource was most recently updated."@en ;
     rdfs:subPropertyOf dcmi:modified ;
     rdfs:range xsd:dateTime ;
     rdfs:domain :Metadata ;
@@ -108,7 +108,7 @@
 :deletedAt
     a rdf:Property ;
     rdfs:label "deletedAt"@en ;
-    dc:description "Time at which the resource was deleted or soft deleted."@en ;
+    dc:description "Time at which the resource was deleted or soft-deleted."@en ;
     rdfs:range xsd:dateTime ;
     rdfs:domain :Metadata, :Tombstone ;
     rdfs:isDefinedBy : .
@@ -131,7 +131,7 @@
 :date
     a rdf:Property ;
     rdfs:label "date"@en ;
-    dc:description "Time at which the operation happened."@en ;
+    dc:description "Time at which the operation was performed."@en ;
     rdfs:subPropertyOf dcmi:created ;
     rdfs:range xsd:dateTime ;
     rdfs:domain :Operation ;

--- a/solid-crdt.ttl
+++ b/solid-crdt.ttl
@@ -1,0 +1,138 @@
+@prefix : <https://w3.org/ns/crdt#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix dcmi: <http://purl.org/dc/dcmitype/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#dateTime> .
+
+<https://w3.org/ns/crdt#>
+    a owl:Ontology ;
+    rdfs:label "Conflict-Free Replicated Datatypes (CRDT)"@en ;
+    dc:description "The Conflict-Free Replicated Datatypes (CRDT) vocabulary can be used to describe changes made to resources over time"@en ;
+    rdfs:isDefinedBy : ;
+    dc:issued "2022-05-26"^^xsd:date ;
+    vann:preferredNamespacePrefix "crdt"@en ;
+    vann:preferredNamespaceUri "http://www.w3.org/ns/solid/crdt#"^^xsd:anyURI .
+
+:Metadata
+    a rdfs:Class ;
+    rdfs:label "Metadata"@en ;
+    dc:description "Metadata about a resource."@en ;
+    rdfs:subClassOf dcmi:Dataset ;
+    rdfs:isDefinedBy : .
+
+:Operation
+    a rdfs:Class ;
+    rdfs:label "Operation"@en ;
+    dc:description "Operation performed on a resource."@en ;
+    rdfs:subClassOf dcmi:Dataset ;
+    rdfs:isDefinedBy : .
+
+:DeleteOperation
+    a rdfs:Class ;
+    rdfs:label "Delete Operation"@en ;
+    dc:description "Operation that soft deletes a resource."@en ;
+    rdfs:subClassOf :Operation ;
+    rdfs:isDefinedBy : .
+
+:PropertyOperation
+    a rdfs:Class ;
+    rdfs:label "Property Operation"@en ;
+    dc:description "Operation affecting a resource's property."@en ;
+    rdfs:subClassOf :Operation ;
+    rdfs:isDefinedBy : .
+
+:SetPropertyOperation
+    a rdfs:Class ;
+    rdfs:label "Set Property Operation"@en ;
+    dc:description "Operation that replaces a resource's property."@en ;
+    rdfs:subClassOf :PropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:UnsetPropertyOperation
+    a rdfs:Class ;
+    rdfs:label "Unset Property Operation"@en ;
+    dc:description "Operation that removes a resource's property."@en ;
+    rdfs:subClassOf :PropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:AddPropertyOperation
+    a rdfs:Class ;
+    rdfs:label "Add Property Operation"@en ;
+    dc:description "Operation that adds values to a resource's property."@en ;
+    rdfs:subClassOf :PropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:RemovePropertyOperation
+    a rdfs:Class ;
+    rdfs:label "Remove Property Operation"@en ;
+    dc:description "Operation that removes values from a resource's property."@en ;
+    rdfs:subClassOf :PropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:Tombstone
+    a rdfs:Class ;
+    rdfs:label "Tombstone"@en ;
+    dc:description "Metadata left behind for a resource that has been deleted."@en ;
+    rdfs:isDefinedBy : .
+
+:resource
+    a rdf:Property ;
+    rdfs:label "resource"@en ;
+    dc:description "Resource which the metadata or tombstone make reference to, or is affected by the operation."@en ;
+    rdfs:subPropertyOf dcmi:subject ;
+    rdfs:range rdfs:Resource ;
+    rdfs:domain :Metadata, :Operation, :Tombstone ;
+    rdfs:isDefinedBy : .
+
+:createdAt
+    a rdf:Property ;
+    rdfs:label "createdAt"@en ;
+    dc:description "Time at which the resource was created."@en ;
+    rdfs:subPropertyOf dcmi:created ;
+    rdfs:range xsd:dateTime ;
+    rdfs:domain :Metadata ;
+    rdfs:isDefinedBy : .
+
+:updatedAt
+    a rdf:Property ;
+    rdfs:label "updatedAt"@en ;
+    dc:description "Time at which the resource was updated for the last time."@en ;
+    rdfs:subPropertyOf dcmi:modified ;
+    rdfs:range xsd:dateTime ;
+    rdfs:domain :Metadata ;
+    rdfs:isDefinedBy : .
+
+:deletedAt
+    a rdf:Property ;
+    rdfs:label "deletedAt"@en ;
+    dc:description "Time at which the resource was deleted or soft deleted."@en ;
+    rdfs:range xsd:dateTime ;
+    rdfs:domain :Metadata, :Tombstone ;
+    rdfs:isDefinedBy : .
+
+:property
+    a rdf:Property ;
+    rdfs:label "property"@en ;
+    dc:description "Property affected by the operation."@en ;
+    rdfs:range rdf:Property ;
+    rdfs:domain :PropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:value
+    a rdf:Property ;
+    rdfs:label "value"@en ;
+    dc:description "Property value used by the operation."@en ;
+    rdfs:domain :SetPropertyOperation, :AddPropertyOperation, :RemovePropertyOperation ;
+    rdfs:isDefinedBy : .
+
+:date
+    a rdf:Property ;
+    rdfs:label "date"@en ;
+    dc:description "Time at which the operation happened."@en ;
+    rdfs:subPropertyOf dcmi:created ;
+    rdfs:range xsd:dateTime ;
+    rdfs:domain :Operation ;
+    rdfs:isDefinedBy : .


### PR DESCRIPTION
I'm about to release a new app I'm working on, and I've created a new vocab to track changes in resources. I'm calling it "CRDT" because I intended to implement a [CRDT (Conflict-Free Replicated Datatype)](https://en.wikipedia.org/wiki/Conflict-free_replicated_data_type) data structure, using the Solid POD as storage. I'm not entirely sure if this is technically a CRDT or not, so I would be fine calling this "history tracking" or something else as well. For more background on this, we discussed it in the Solid forum in this thread: [Request for Comments: CRDTish approach to Solid](https://forum.solidproject.org/t/request-for-comments-crdtish-approach-to-solid/4211).

Initially, I intended to host this myself at `https://vocab.noeldemartin.com/crdt` or something, but talking with @timbl he mentioned that maybe this would make sense as a `w3.org` vocab. So here it is. I'm not entirely sure if this gets merged how the actual `w3.org/ns/crdt` url is configured and if I'll be able to modify the html or something. Or is that just auto-generated from this repository?

For an example of data using this vocab, you can look at the following files which represent changes made to a document over time (the parts within [[ ]] are just placeholders that will be replaced during testing, so assume those are real values):

- Document creation: [ramen.ttl](https://github.com/NoelDeMartin/umai/blob/main/cypress/fixtures/ramen.ttl)
- Document updates:
    - [update-ramen-1.sparql](https://github.com/NoelDeMartin/umai/blob/main/cypress/fixtures/update-ramen-1.sparql)
    - [update-ramen-2.sparql](https://github.com/NoelDeMartin/umai/blob/main/cypress/fixtures/update-ramen-2.sparql)
    - [update-ramen-3.sparql](https://github.com/NoelDeMartin/umai/blob/main/cypress/fixtures/update-ramen-3.sparql)