### PR TITLE
Add describes, fix link relation, fix typo in ACL Ontology

### DIFF
--- a/acl.n3
+++ b/acl.n3
@@ -1,4 +1,4 @@
-@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dct: <http://purl.org/dc/terms/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix gen: <http://www.w3.org/2006/gen/ont#>.
 @prefix foaf: <http://xmlns.com/foaf/0.1/>.
@@ -8,13 +8,13 @@
 @prefix : <http://www.w3.org/ns/auth/acl#>.
 
 
-<> dc:title "Basic Access Control ontology";
+<> dct:title "Basic Access Control ontology";
     rdfs:comment """Defines the class Authorization and its essential properties,
     and also some classes of access such as read and write. """.
 
-<https://www.w3.org/wiki/WebAccessControl> dc:describes <>.
-<https://github.com/solid/web-access-control-spec> dc:describes <>.
-<https://solidproject.org/TR/wac> dc:describes <>.
+<https://www.w3.org/wiki/WebAccessControl> dct:description <>.
+<https://github.com/solid/web-access-control-spec> dct:description <>.
+<https://solidproject.org/TR/wac> dct:description <>.
 
 :Authorization a rdfs:Class;
     rdfs:label  "authorization";

--- a/acl.n3
+++ b/acl.n3
@@ -158,7 +158,7 @@ and for example to develop a reputation)
         rdfs:subPropertyOf rdfs:seeAlso;
         rdfs:comment """The Access Control file for this information resource.
         This may of course be a virtual resource implemented by the access control system.
-        Note also HTTP's header Link: <foo.acl>; rel="acl" can be used for this.""";
+        Note that HTTP header `Link: <foo.acl>; rel="acl"` can also be used for this.""";
         rdfs:domain      gen:InformationResource;
         rdfs:range      gen:InformationResource.
 
@@ -169,8 +169,8 @@ and for example to develop a reputation)
     rdfs:range foaf:Agent;
     rdfs:comment """The person or other agent which owns this.
     For example, the owner of a file in a filesystem.
-    There is a sense of right to control.   Typically defaults to the agent who created
-    something but can be changed.""".
+    There is a sense of "right to control".   Typically defaults to the agent who created
+    something, but can be changed.""".
 
 :delegates a rdf:Property;
     rdfs:label "delegates"@en;

--- a/acl.n3
+++ b/acl.n3
@@ -14,7 +14,7 @@
 
 <https://www.w3.org/wiki/WebAccessControl> dc:describes <>.
 <https://github.com/solid/web-access-control-spec> dc:describes <>.
-
+<https://solidproject.org/TR/wac> dc:describes <>.
 
 :Authorization a rdfs:Class;
     rdfs:label  "authorization";
@@ -158,7 +158,7 @@ and for example to develop a reputation)
         rdfs:subPropertyOf rdfs:seeAlso;
         rdfs:comment """The Access Control file for this information resource.
         This may of course be a virtual resource implemented by the access control system.
-        Note also HTTP's header  Link:  foo.meta ;rel=meta can be used for this.""";
+        Note also HTTP's header Link: <foo.acl>; rel="acl" can be used for this.""";
         rdfs:domain      gen:InformationResource;
         rdfs:range      gen:InformationResource.
 
@@ -169,7 +169,7 @@ and for example to develop a reputation)
     rdfs:range foaf:Agent;
     rdfs:comment """The person or other agent which owns this.
     For example, the owner of a file in a filesystem.
-    There is a sense of right to control.   Typically defaults to the agent who craeted
+    There is a sense of right to control.   Typically defaults to the agent who created
     something but can be changed.""".
 
 :delegates a rdf:Property;

--- a/acl.n3
+++ b/acl.n3
@@ -12,8 +12,8 @@
     rdfs:comment """Defines the class Authorization and its essential properties,
     and also some classes of access such as read and write. """.
 
-<https://www.w3.org/wiki/WebAccessControl> dct:description <>.
-<https://solidproject.org/TR/wac> dct:description <>.
+<https://www.w3.org/wiki/WebAccessControl> foaf:topic <>.
+<https://solidproject.org/TR/wac> foaf:topic <>.
 
 :Authorization a rdfs:Class;
     rdfs:label  "authorization";

--- a/acl.n3
+++ b/acl.n3
@@ -13,7 +13,6 @@
     and also some classes of access such as read and write. """.
 
 <https://www.w3.org/wiki/WebAccessControl> dct:description <>.
-<https://github.com/solid/web-access-control-spec> dct:description <>.
 <https://solidproject.org/TR/wac> dct:description <>.
 
 :Authorization a rdfs:Class;

--- a/acl.n3
+++ b/acl.n3
@@ -158,6 +158,7 @@ and for example to develop a reputation)
         rdfs:comment """The Access Control file for this information resource.
         This may of course be a virtual resource implemented by the access control system.
         Note that HTTP header `Link: <foo.acl>; rel="acl"` can also be used for this.""";
+        rdfs:seeAlso <https://solidproject.org/TR/wac#acl-link-relation>;
         rdfs:domain      gen:InformationResource;
         rdfs:range      gen:InformationResource.
 


### PR DESCRIPTION
* Add statement about the WAC spec describing ACL.
* Fix comment about using the acl Link Relation - registered at IANA - as alternative to acl:accessControl property.
* Fix typo in acl:owner comment.