### PR TITLE
add properties for an agent's personal pronouns

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -182,6 +182,13 @@ solid:notification
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "notification"@en .
 
+solid:objectivePronoun
+    a rdf:Property ;
+    dc:issued "2022-09-16"^^xsd:date ;
+    rdfs:comment "String for an agent's personal objective pronoun, e.g., her, him, them."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:label "personal objective pronoun"@en .
+
 solid:oidcIssuer
     a rdf:Property ;
     dc:issued "2017-08-15"^^xsd:date ;
@@ -199,6 +206,13 @@ solid:patches
     rdfs:label "patches"@en ;
     rdfs:domain solid:Patch ;
     rdfs:range rdfs:Resource .
+
+solid:possessivePronoun
+    a rdf:Property ;
+    dc:issued "2022-09-16"^^xsd:date ;
+    rdfs:comment "String for an agent's personal possessive pronoun, e.g., hers, his, theirs."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:label "personal possessive pronoun"@en .
 
 solid:privateTypeIndex
     a rdf:Property ;
@@ -242,6 +256,13 @@ solid:storageUsage
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:domain solid:Account ;
     rdfs:label "Non-volatile memory usage"@en .
+
+solid:subjectPronoun
+    a rdf:Property ;
+    dc:issued "2022-09-16"^^xsd:date ;
+    rdfs:comment "String for an agent's personal subject pronoun, e.g., she, he, they."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:label "personal subject pronoun"@en .
 
 solid:typeIndex
     a rdf:Property ;


### PR DESCRIPTION
Adds properties for personal pronouns based on discussion on https://github.com/solid/vocab/issues/79. 

After these are added, SolidOS and PodBrowser will have to update their usage of `preferred` pronouns to these. 