### PR TITLE
Add Solid Notifications vocabulary and JSON-LD context

### DIFF
--- a/solid-notifications-context.jsonld
+++ b/solid-notifications-context.jsonld
@@ -15,7 +15,7 @@
 
     "channelType": {
       "@id": "notify:channelType",
-      "@type": "@id" },
+      "@type": "@vocab" },
 
     "endAt": {
       "@id": "notify:endAt",
@@ -49,7 +49,7 @@
 
     "topic": {
       "@id": "notify:topic",
-      "@type": "@id" },
+      "@type": "@id" }
 
   }
 }

--- a/solid-notifications-context.jsonld
+++ b/solid-notifications-context.jsonld
@@ -9,9 +9,13 @@
 
     "accept": "notify:accept",
 
-    "startAt": {
-      "@id": "notify:startAt",
-      "@type": "xsd:dateTime" },
+    "channel": {
+      "@id": "notify:channel",
+      "@type": "@id" },
+
+    "channelType": {
+      "@id": "notify:channelType",
+      "@type": "@id" },
 
     "endAt": {
       "@id": "notify:endAt",
@@ -21,19 +25,9 @@
       "@id": "notify:feature",
       "@type": "@vocab" },
 
-    "channel": {
-      "@id": "notify:channel",
-      "@type": "@id" },
-
-    "channelType": {
-      "@id": "notify:channelType",
-      "@type": "@id" },
-
     "rate": {
       "@id": "notify:rate",
       "@type": "xsd:duration" },
-
-    "state": "notify:state",
 
     "receiveFrom": {
       "@id": "notify:receiveFrom",
@@ -42,7 +36,13 @@
     "sendTo": {
       "@id": "notify:sendTo",
       "@type": "@id" },
-      
+
+    "state": "notify:state",
+
+    "startAt": {
+      "@id": "notify:startAt",
+      "@type": "xsd:dateTime" },
+
     "subscription": {
       "@id": "notify:subscription",
       "@type": "@id" },

--- a/solid-notifications-context.jsonld
+++ b/solid-notifications-context.jsonld
@@ -33,6 +33,10 @@
       "@id": "notify:receiveFrom",
       "@type": "@id" },
 
+    "sender": {
+      "@id": "notify:sender",
+      "@type": "@id" },
+
     "sendTo": {
       "@id": "notify:sendTo",
       "@type": "@id" },
@@ -50,6 +54,5 @@
     "topic": {
       "@id": "notify:topic",
       "@type": "@id" }
-
   }
 }

--- a/solid-notifications-context.jsonld
+++ b/solid-notifications-context.jsonld
@@ -1,0 +1,55 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "notify": "http://www.w3.org/ns/solid/notifications#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+    "accept": "notify:accept",
+
+    "startAt": {
+      "@id": "notify:startAt",
+      "@type": "xsd:dateTime" },
+
+    "endAt": {
+      "@id": "notify:endAt",
+      "@type": "xsd:dateTime" },
+
+    "feature": {
+      "@id": "notify:feature",
+      "@type": "@vocab" },
+
+    "channel": {
+      "@id": "notify:channel",
+      "@type": "@id" },
+
+    "channelType": {
+      "@id": "notify:channelType",
+      "@type": "@id" },
+
+    "rate": {
+      "@id": "notify:rate",
+      "@type": "xsd:duration" },
+
+    "state": "notify:state",
+
+    "receiveFrom": {
+      "@id": "notify:receiveFrom",
+      "@type": "@id" },
+
+    "sendTo": {
+      "@id": "notify:sendTo",
+      "@type": "@id" },
+      
+    "subscription": {
+      "@id": "notify:subscription",
+      "@type": "@id" },
+
+    "topic": {
+      "@id": "notify:topic",
+      "@type": "@id" },
+
+  }
+}

--- a/solid-notifications-context.jsonld
+++ b/solid-notifications-context.jsonld
@@ -7,6 +7,12 @@
     "notify": "http://www.w3.org/ns/solid/notifications#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
 
+    "EventSourceChannel2023": "notify:EventSourceChannel2023",
+    "LDNChannel2023": "notify:LDNChannel2023",
+    "StreamingHTTPChannel2023": "notify:StreamingHTTPChannel2023",
+    "WebhookChannel2023": "notify:WebhookChannel2023",
+    "WebSocketChannel2023": "notify:WebSocketChannel2023",
+
     "accept": "notify:accept",
 
     "channel": {

--- a/solid-notifications.ttl
+++ b/solid-notifications.ttl
@@ -1,0 +1,114 @@
+@prefix notify: <http://www.w3.org/ns/solid/notifications#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix dc: <http://purl.org/dc/terms/> .
+@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+
+<http://www.w3.org/ns/solid/notifications#>
+    a owl:Ontology ;
+    dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
+    rdfs:label "Solid Notifications"@en ;
+    rdfs:comment "The vocabulary used by the Solid Notification protocol specification."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    rdfs:seeAlso <https://solidproject.org/TR/notifications-protocol>
+    dc:issued "2022-12-31"^^xsd:date ;
+    vann:preferredNamespacePrefix "notify" ;
+    vann:preferredNamespaceUri "http://www.w3.org/ns/solid/notifications#"^^xsd:anyURI .
+
+# ---------
+#  Classes
+# ---------
+#notify:WebSocketChannel2023
+#    a rdf:Class ;
+#    rdfs:label "WebSocket Channel 2023"@en ;
+#    rdfs:comment "A notification channel type that uses the WebSocket API."@en ;
+#    rdfs:isDefinedBy <https://solidproject.org/TR/websocket-channel-2023> ;
+
+#notify:LDNChannel2023
+#    a rdf:Class ;
+#    rdfs:label "LDN Channel 2023"@en ;
+#    rdfs:comment "A notification channel type that uses the Linked Data Notifications protocol."@en ;
+#    rdfs:isDefinedBy <https://solidproject.org/TR/ldn-channel-2023> ;
+    vs:term_status "testing" .
+
+# ------------
+#  Properties
+# ------------
+notify:accept
+    a rdf:Property ;
+    rdfs:label "accept"@en ;
+    rdfs:comment "The media types that are acceptable by the recipient of a notification with value corresponding to the HTTP Accept header value [RFC7231]."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:startAt
+    a rdf:Property ;
+    rdfs:label "start at"@en ;
+    rdfs:comment "The proposed or actual starting date and time of a notification channel with value represented in the xsd:dateTime datatype."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+notify:endAt
+    a rdf:Property ;
+    rdfs:label "end at"@en ;
+    rdfs:comment "The proposed or actual ending date and time of a notification channel with value represented in the xsd:dateTime datatype."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:feature
+    a rdf:Property ;
+    rdfs:label "feature"@en ;
+    rdfs:comment "A property used to describe the features supported by a particular notification channel."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:channel
+    a rdf:Property ;
+    rdfs:label "notification channel"@en ;
+    rdfs:comment "A property used to indicate an available notification channel."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:rate
+    a rdf:Property ;
+    rdfs:label "rate"@en ;
+    rdfs:comment "The minimum amount of time to elapse between notifications sent to receiver with value represented in the xsd:duration datatype."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:receiveFrom
+    a rdf:Property ;
+    rdfs:label "receive from"@en ;
+    rdfs:comment "The property used to identify the resource that can be used to establish a connection to receive notifications."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:sendTo
+    a rdf:Property ;
+    rdfs:label "send to"@en ;
+    rdfs:comment "The property used to identify the resource that can accept notifications."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+notify:state
+    a rdf:Property ;
+    rdfs:label "state"@en ;
+    rdfs:comment "The last known state of a resource (topic) with value represented in the xsd:string datatype."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:subscription
+    a rdf:Property ;
+    rdfs:label "subscription"@en ;
+    rdfs:comment "A property used to indicate an available subscription resource."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
+notify:topic
+    a rdf:Property ;
+    rdfs:label "topic"@en ;
+    rdfs:comment "The IRI of a resource about which a client would like to receive notifications."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+

--- a/solid-notifications.ttl
+++ b/solid-notifications.ttl
@@ -86,6 +86,13 @@ notify:receiveFrom
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
 
+notify:sender
+    a rdf:Property ;
+    rdfs:label "sender"@en ;
+    rdfs:comment "The property used to identify the party that sends notifications."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
 notify:sendTo
     a rdf:Property ;
     rdfs:label "send to"@en ;

--- a/solid-notifications.ttl
+++ b/solid-notifications.ttl
@@ -13,7 +13,7 @@
     rdfs:label "Solid Notifications"@en ;
     rdfs:comment "The vocabulary used by the Solid Notification protocol specification."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
-    rdfs:seeAlso <https://solidproject.org/TR/notifications-protocol>
+    rdfs:seeAlso <https://solidproject.org/TR/notifications-protocol> ;
     dc:issued "2022-12-31"^^xsd:date ;
     vann:preferredNamespacePrefix "notify" ;
     vann:preferredNamespaceUri "http://www.w3.org/ns/solid/notifications#"^^xsd:anyURI .
@@ -32,7 +32,7 @@
 #    rdfs:label "LDN Channel 2023"@en ;
 #    rdfs:comment "A notification channel type that uses the Linked Data Notifications protocol."@en ;
 #    rdfs:isDefinedBy <https://solidproject.org/TR/ldn-channel-2023> ;
-    vs:term_status "testing" .
+#    vs:term_status "testing" .
 
 # ------------
 #  Properties
@@ -44,12 +44,20 @@ notify:accept
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
 
-notify:startAt
+notify:channel
     a rdf:Property ;
-    rdfs:label "start at"@en ;
-    rdfs:comment "The proposed or actual starting date and time of a notification channel with value represented in the xsd:dateTime datatype."@en ;
+    rdfs:label "notification channel"@en ;
+    rdfs:comment "A property used to indicate an available notification channel."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
+
+notify:channelType
+    a rdf:Property ;
+    rdfs:label "notification channel type"@en ;
+    rdfs:comment "A property used to indicate the notification channel type."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
 notify:endAt
     a rdf:Property ;
     rdfs:label "end at"@en ;
@@ -61,13 +69,6 @@ notify:feature
     a rdf:Property ;
     rdfs:label "feature"@en ;
     rdfs:comment "A property used to describe the features supported by a particular notification channel."@en ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
-    vs:term_status "testing" .
-
-notify:channel
-    a rdf:Property ;
-    rdfs:label "notification channel"@en ;
-    rdfs:comment "A property used to indicate an available notification channel."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
 
@@ -91,6 +92,14 @@ notify:sendTo
     rdfs:comment "The property used to identify the resource that can accept notifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
+
+notify:startAt
+    a rdf:Property ;
+    rdfs:label "start at"@en ;
+    rdfs:comment "The proposed or actual starting date and time of a notification channel with value represented in the xsd:dateTime datatype."@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
+    vs:term_status "testing" .
+
 notify:state
     a rdf:Property ;
     rdfs:label "state"@en ;
@@ -111,4 +120,3 @@ notify:topic
     rdfs:comment "The IRI of a resource about which a client would like to receive notifications."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
-

--- a/solid-notifications.ttl
+++ b/solid-notifications.ttl
@@ -117,7 +117,7 @@ notify:state
 notify:subscription
     a rdf:Property ;
     rdfs:label "subscription"@en ;
-    rdfs:comment "A property used to indicate an available subscription resource."@en ;
+    rdfs:comment "A property used to indicate an available subscription service."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     vs:term_status "testing" .
 

--- a/solid-notifications.ttl
+++ b/solid-notifications.ttl
@@ -11,7 +11,7 @@
     a owl:Ontology ;
     dc:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
     rdfs:label "Solid Notifications"@en ;
-    rdfs:comment "The vocabulary used by the Solid Notification protocol specification."@en ;
+    rdfs:comment "The vocabulary used by the Solid Notifications Protocol specification."@en ;
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/notifications#> ;
     rdfs:seeAlso <https://solidproject.org/TR/notifications-protocol> ;
     dc:issued "2022-12-31"^^xsd:date ;
@@ -21,18 +21,40 @@
 # ---------
 #  Classes
 # ---------
-#notify:WebSocketChannel2023
-#    a rdf:Class ;
-#    rdfs:label "WebSocket Channel 2023"@en ;
-#    rdfs:comment "A notification channel type that uses the WebSocket API."@en ;
-#    rdfs:isDefinedBy <https://solidproject.org/TR/websocket-channel-2023> ;
+notify:EventSourceChannel2023
+    a rdf:Class ;
+    rdfs:label "EventSourceChannel2023" ;
+    rdfs:comment "A notification channel type that uses the EventSource Web API."@en ;
+    rdfs:isDefinedBy <https://solid.github.io/notifications/eventsource-channel-2023> ;
+    vs:term_status "testing" .
 
-#notify:LDNChannel2023
-#    a rdf:Class ;
-#    rdfs:label "LDN Channel 2023"@en ;
-#    rdfs:comment "A notification channel type that uses the Linked Data Notifications protocol."@en ;
-#    rdfs:isDefinedBy <https://solidproject.org/TR/ldn-channel-2023> ;
-#    vs:term_status "testing" .
+notify:LDNChannel2023
+    a rdf:Class ;
+    rdfs:label "LDNChannel2023" ;
+    rdfs:comment "A notification channel type that uses the Linked Data Notifications protocol."@en ;
+    rdfs:isDefinedBy <https://solid.github.io/notifications/ldn-channel-2023> ;
+    vs:term_status "testing" .
+
+notify:StreamingHTTPChannel2023
+    a rdf:Class ;
+    rdfs:label "StreamingHTTPChannel2023" ;
+    rdfs:comment "A notification channel type that uses the Fetch API."@en ;
+    rdfs:isDefinedBy <https://solid.github.io/notifications/streaming-http-channel-2023> ;
+    vs:term_status "testing" .
+
+notify:WebhookChannel2023
+    a rdf:Class ;
+    rdfs:label "WebhookChannel2023" ;
+    rdfs:comment "A notification channel type that uses Webhooks."@en ;
+    rdfs:isDefinedBy <https://solid.github.io/notifications/webhook-channel-2023> ;
+    vs:term_status "testing" .
+
+notify:WebSocketChannel2023
+    a rdf:Class ;
+    rdfs:label "WebSocketChannel2023" ;
+    rdfs:comment "A notification channel type that uses the WebSocket API."@en ;
+    rdfs:isDefinedBy <https://solid.github.io/notifications/websocket-channel-2023> ;
+    vs:term_status "testing" .
 
 # ------------
 #  Properties


### PR DESCRIPTION
This PR follows https://github.com/solid/vocab/pull/62 and accompanied with https://github.com/solid/specification/pull/491 .

This defines a JSON-LD `@context` for use with the [Solid Notifications Protocol, Version 0.2.0](https://solidproject.org/TR/2022/notifications-protocol-20221231) (see also [ED](https://solid.github.io/notifications/protocol)).

The notification specification describes this resource as being available at `https://www.w3.org/ns/solid/notification/v1`.

In addition, this defines an RDF vocabulary for the terms used in the [Solid Notifications Protocol, Version 0.2.0](https://solidproject.org/TR/2022/notifications-protocol-20221231) (see also [ED](https://solid.github.io/notifications/protocol)). A Turtle serialization (possibly in addition to other concrete RDF syntaxes) is intended to be available from `http://www.w3.org/ns/solid/notifications`.