### PR TITLE
add privateLabelIndex

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -227,6 +227,14 @@ solid:publicTypeIndex
     rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "public type index"@en .
 
+solid:privateLabelIndex
+    a rdf:Property ;
+    dc:issued "2023-10-04"^^xsd:date ;
+    rdfs:comment "Points to an unlisted label index resource."@en ;
+    rdfs:range solid:UnlistedDocument ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:label "private label index"@en .
+
 solid:read
     a rdf:Property ;
     dc:issued "2015-12-18"^^xsd:date ;


### PR DESCRIPTION
This is a term used (currently) by PodOS to do a full text search, but is of general purpose to make things findable based on their label also to other apps.

I described here, how to make use of it for the PodOS search feature: https://github.com/pod-os/PodOS/blob/main/docs/features/full-text-search.md

I also discussed it with @timbl and the SolidOS team in today's team call and we agreed on adding it to the solid terms.