### PR TITLE
Add advisement property and class

### DIFF
--- a/spec.ttl
+++ b/spec.ttl
@@ -18,7 +18,7 @@ spec:
   dcterms:issued "2021-06-04"^^xsd:date ;
   dcterms:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
   owl:versionInfo [
-    dcterms:date "2023-07-24"^^xsd:date ;
+    dcterms:date "2024-05-26"^^xsd:date ;
 #    dcterms:replaces <> ;
 #    rdfs:seeAlso <> ;
   ] ;
@@ -59,6 +59,20 @@ spec:requirementReference
   rdfs:label "requirement reference"@en ;
   rdfs:domain test-description:SpecificationTestCase ;
   rdfs:range spec:Requirement .
+
+spec:advisement
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "advisement"@en ;
+  rdfs:range spec:Advisement .
+
+spec:Advisement
+  a rdfs:Class ;
+  rdfs:label "Advisement"@en .
+
+spec:advisementLevel
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "advisement level"@en ;
+  rdfs:domain spec:Advisement .
 
 spec:testScript
   a rdf:Property, owl:ObjectProperty ;
@@ -198,11 +212,6 @@ spec:OPTIONAL
 spec:AdvisementLevel
   a skos:ConceptScheme ;
   skos:prefLabel "Advisement Level"@en .
-
-spec:advisementLevel
-  a rdf:Property, owl:ObjectProperty ;
-  rdfs:label "advisement"@en ;
-  rdfs:range spec:Advisement .
 
 spec:StronglyEncouraged
   a skos:Concept ;


### PR DESCRIPTION
Add `spec:advisement` property (to discover advisements) and `spec:Advisement` class.

Advisements are similar to Requirements.

Advisements are marked in the Solid Protocol: https://solidproject.org/ED/protocol

Live SPARQL Query selecting advisement, advisementLevel, advisement statement of the above:

https://sparql.org/sparql?query=PREFIX+spec%3A+%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fspec%23%3E%0D%0ASELECT+%3Fadvisement+%3FadvisementLevel+%3FadvisementStatement%0D%0AFROM+%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolidproject.org%252FED%252Fprotocol%26raw%3E%0D%0AWHERE+%7B%0D%0A%3Fs+spec%3Aadvisement+%3Fadvisement+.%0D%0A%3Fadvisement+spec%3AadvisementLevel+%3FadvisementLevel+.%0D%0A%3Fadvisement+spec%3Astatement+%3FadvisementStatement+.%0D%0A%7D&default-graph-uri=&output=xml&stylesheet=%2Fxml-to-html.xsl

Advisements in a table:

![image](https://github.com/solid/vocab/assets/429987/5b1aac5b-eda6-4008-900a-0e0441fda970)

Advisements part of the visualisation graph of the specification:

![image](https://github.com/solid/vocab/assets/429987/fc9d38ee-cbb6-4b73-aeac-0e6081c38a25)
