### PR TITLE
Add changelog

### DIFF
--- a/spec.ttl
+++ b/spec.ttl
@@ -351,6 +351,32 @@ spec:SelfReviewQuestionnaireSecurityPrivacy
   rdfs:seeAlso <https://www.w3.org/TR/security-privacy-questionnaire/> .
 
 
+# Changelog
+spec:Changelog
+  a rdfs:Class ;
+  rdfs:label "Changelog"@en .
+
+spec:Change
+  a rdfs:Class ;
+  rdfs:label "Change"@en .
+
+spec:change
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "change"@en .
+
+spec:changelog
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "changelog"@en .
+
+spec:changeClass
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "change class"@en .
+
+spec:changeSubject
+  a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "change subject"@en .
+
+
 # Variability in Specifications
 spec:Variability
   a rdfs:Class ;


### PR DESCRIPTION
Add properties and classes related to expressing "changelog" information available in technical reports, e.g., change subject, correction or change class (see below), and human-readable statement.

Changelogs are marked in documents such as [Solid Protocol](https://solidproject.org/TR/protocol#changelog), [Solid Notifications Protocol](https://solidproject.org/TR/notifications-protocol#changelog), [Web Access Control](https://solidproject.org/TR/wac#changelog). These reports include "a summary of editorial, substantive, and registry changes are classified using the W3C Process Document [Classes of Changes](https://www.w3.org/Consortium/Process/#correction-classes)".

A human-readable view of an example [changelog of Solid Protocol, v0.11](https://solidproject.org/TR/2024/protocol-20240512#changelog):

![image](https://github.com/solid/vocab/assets/429987/7097b791-97ea-48af-8d6c-21df699e91ba)

Example usage in Turtle connecting document, a particular requirement, with changelog information about that requirement:

```turtle
@prefix spec: <http://www.w3.org/ns/spec#> .
@prefix : <https://solidproject.org/TR/2024/protocol-20240512#> .

<https://solidproject.org/TR/2024/protocol-20240512>
    spec:changelog :changelog ;
    spec:requirement :server-content-type-includes .

:changelog
    spec:change :d18392b9-8ffc-4264-a5a2-10e2da6fac32 .

:d18392b9-8ffc-4264-a5a2-10e2da6fac32
    a spec:Change ;
    spec:changeClass <https://www.w3.org/Consortium/Process/#class-4> ;
    spec:changeSubject :server-content-type-includes ;
    spec:statement "Add requirement for server to include Content-Type header field in messages with content."@en .

:server-content-type-includes
    spec:requirementLevel spec:MUST ;
    spec:requirementSubject :Server ;
    spec:statement "Server MUST generate a Content-Type header field in a message that contains content."@en .
```

Live SPARQL Query selecting changelog information across technical reports:

https://sparql.org/sparql?query=%0D%0APREFIX+spec%3A+%3Chttp%3A%2F%2Fwww.w3.org%2Fns%2Fspec%23%3E%0D%0ASELECT+%3Fdocument+%3Fchange+%3FchangeClass+%3FchangeSubject+%3Fstatement%0D%0AFROM+%0D%0A%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolidproject.org%252FTR%252Fprotocol%26raw%3E%0D%0AFROM+%0D%0A%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolidproject.org%252FTR%252Fwac%26raw%3E%0D%0AFROM+%0D%0A%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolidproject.org%252FTR%252Fnotifications-protocol%26raw%3E%0D%0AFROM+%0D%0A%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolidproject.org%252FED%252Fqa%26raw%3E%0D%0AFROM+%0D%0A%3Chttp%3A%2F%2Frdf.greggkellogg.net%2Fdistiller%3Fcommand%3Dserialize%26format%3Drdfa%26output_format%3Dturtle%26url%3Dhttps%3A%252F%252Fsolid.github.io%252Fwebid-profile%252F%26raw%3E%0D%0AWHERE%7B%0D%0A++%3Fdocument+spec%3Achangelog+%5B%0D%0A++++spec%3Achange+%3Fchange+%3B%0D%0A++%5D+.%0D%0A++%3Fchange%0D%0A++++spec%3AchangeClass+%3FchangeClass+%3B%0D%0A++++spec%3AchangeSubject+%3FchangeSubject+%3B%0D%0A++++spec%3Astatement+%3Fstatement+.%0D%0A%7D%0D%0AORDER+BY+%3Fdocument+%3FchangeClass+%3FchangeSubject&default-graph-uri=&output=xml&stylesheet=%2Fxml-to-html.xsl

An application (e.g., [dokieli](https://dokie.li/)) making use of the changelog information by incorporating into a *Conformance Requirements and Test Coverage* table where a requirement URI is matched with a change subject URI:

![image](https://github.com/solid/vocab/assets/429987/0d5017c3-ab66-4440-99b9-c70d0dc4b968)
