### PR TITLE
Add solid:proxy to Solid Terms

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -215,8 +215,15 @@ solid:privateTypeIndex
     dc:issued "2018-01-24"^^xsd:date ;
     rdfs:comment "Points to an unlisted type index resource."@en ;
     rdfs:range solid:UnlistedDocument ;
-    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
     rdfs:label "private type index"@en .
+
+solid:proxy
+    a rdf:Property ;
+    dc:issue "2024-10-10"^^xsd:date ;
+    rdfs:comment """A proxy endpoint for applications to use. The value of the property is intended to be used as the base URL for the request, e.g., the proxy as literal: `https://example.org/proxy?uri=` would be used to request `https://example.net/profile/card#me` as `https://example.org/proxy?uri=https://example.net/profile/card%23me`"""@en ;
+    rdfs:label "proxy"@en ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:range rdfs:Literal .
 
 solid:publicTypeIndex
     a rdf:Property ;


### PR DESCRIPTION
Resolves https://github.com/solid/vocab/issues/26 after taking feedback into account. This proposal is more generic than the one in the issue so that it can essentially be used by any thing that wishes to advertise a proxy endpoint. It was initially proposed as an agent's preferred proxy but it can also be advertised by a storage as mentioned in the issue, as well as the use case as part of communication options mentioned in storage description: https://github.com/solid/specification/issues/355#use-cases

https://dokie.li/ (source: https://git.dokie.li/ ) has implemented `solid:preferredProxy`, and if this PR is accepted, there are no issues (or barriers) to make the change to `solid:proxy` immediately.

Applications such as dokieli get around CORS limitations (either servers not participating or not implemented properly) on the Web by using user's preferred proxy, which acts as a fallback. In addition to that, the user can also hide their application's Origin.

The notion of an agent/actor having a reliable proxy is also mentioned in specifications such as ActivityPub: https://www.w3.org/TR/activitypub/#proxyUrl

An open source Solid server such as NSS ( https://github.com/nodeSolidServer/node-solid-server/ ) has implemented the proxy from earlier on.