### PR TITLE
Add the solid:storageDescription property to Solid Terms

### DIFF
--- a/solid-terms.ttl
+++ b/solid-terms.ttl
@@ -243,6 +243,14 @@ solid:read
     rdfs:domain <http://rdfs.org/sioc/ns#Post> ;
     rdfs:label "read"@en .
 
+solid:storageDescription
+    a rdf:Property , owl:ObjectProperty ;
+    dc:issued "2024-12-28"^^xsd:date ;
+    rdfs:comment "Refers to the resource that provides a description of the storage containing this resource."@en ;
+    rdfs:seeAlso <https://solidproject.org/TR/2024/protocol-20240512#server-storage-description> ;
+    rdfs:isDefinedBy <http://www.w3.org/ns/solid/terms#> ;
+    rdfs:label "storage description"@en .
+
 solid:storageQuota
     a rdf:Property, owl:DatatypeProperty ;
     dc:issued "2018-10-26"^^xsd:date ;


### PR DESCRIPTION
Follows https://github.com/solid/specification/pull/416

The property was originally referenced in https://solidproject.org/TR/2022/protocol-20221231#server-storage-description but using the latest reference: https://solidproject.org/TR/2024/protocol-20240512#server-storage-description in the property definition since it has a minor clarification about "field".